### PR TITLE
Add entr-like functionality.

### DIFF
--- a/lib/arguments.moon
+++ b/lib/arguments.moon
@@ -22,6 +22,11 @@ load_spookfile = _G.load_spookfile
 -- Require some things that come with spook
 fs = require 'fs'
 
+-- We want to use the coroutine based execute which can also be
+-- interrupted using ctrl-c etc. I would recommend this most of the
+-- time even though os.execute works just fine (except for job control etc).
+execute = require('process').execute
+
 -- notify is a global variable. Let's make it a local
 -- as is generally recommended in Lua.
 -- Let's add the built-in terminal_notifier.
@@ -54,14 +59,14 @@ pcall notify.add, 'notifier'
 rspec = (file) ->
   return true unless fs.is_file file
   note.info "RUNNING rspec #{file}"
-  _, _, status = os.execute "./bin/rspec -f d #{file}"
+  _, _, status = execute "./bin/rspec -f d #{file}"
   assert status == 0, "rspec #{file} - failed"
 
 -- And another for running ruby
 ruby = (file) ->
   return true unless fs.is_file file
   note.info "RUNNING ruby #{file}"
-  _, _, status = os.execute "ruby #{file}"
+  _, _, status = execute "ruby #{file}"
   assert status == 0, "ruby #{file} - failed"
   status == 0
 
@@ -122,5 +127,9 @@ parser\option("-w --dir", "Expects the path to working directory - overrides the
     os.exit 1
 
 parser\option("-f --file", "Expects a path to a moonscript file - this runs the script within the context of spook, skipping the default behavior completely")\args(1)
+
+parser\flag("-s", "In entr mode, start the given utility immediately without waiting for changes first - can't be used with -o")
+
+parser\flag("-o", "In entr mode, exit immediately after running utility - can't be used with -s")
 
 parser

--- a/lib/spookfile_helpers.moon
+++ b/lib/spookfile_helpers.moon
@@ -1,5 +1,6 @@
 log = _G.log
 notify = _G.notify
+:execute = require 'process'
 
 -- Run the same task regardless of fs change
 -- until that task succeeds.
@@ -18,8 +19,8 @@ command = (cmd, opts={}) ->
   (file) ->
     cmdline = "#{cmd} #{file}"
     notify.info cmdline
-    _, _, status = execute cmdline
-    assert status == 0, cmdline
+    success = execute cmdline
+    assert success, cmdline
 
 -- For filtering commands not runnable
 -- for example when the mapped file does

--- a/lint_config.lua
+++ b/lint_config.lua
@@ -10,7 +10,8 @@ return {
       'watch_file',
       'notifier',
       'log_level',
-      'first_match_only'
+      'first_match_only',
+      'one_fs_handler_at_a_time'
     },
     ["lib/config.moon"] = {
       'log_level',

--- a/spec/spook_spec.moon
+++ b/spec/spook_spec.moon
@@ -128,3 +128,12 @@ describe 'spook', ->
         first_match_only false
 
       assert.false spook.first_match_only
+
+    it '#one_fs_handler_at_a_time is true by default', ->
+      assert.true spook.one_fs_handler_at_a_time
+
+    it 'configures one_fs_handler_at_a_time via supplied function', ->
+      spook ->
+        one_fs_handler_at_a_time false
+
+      assert.false spook.one_fs_handler_at_a_time


### PR DESCRIPTION
This implements entr like functionality. Basically, if there's anything (when starting up) on stdin it will assume an entr like identity where files to watch are expected on stdin and a command should be given to spook to run when something does change. Basically:

```sh
find . -type f | spook echo file: {file}
```