### PR TITLE
Allow env for commands. Actually use spook execute in command.

### DIFF
--- a/lib/spookfile_helpers.moon
+++ b/lib/spookfile_helpers.moon
@@ -15,11 +15,14 @@ until_success = (func) ->
 -- Wraps a command that takes a file
 -- as input.
 command = (cmd, opts={}) ->
-  execute = opts.execute or os.execute
-  (file) ->
+  command_env = opts.env or {}
+  (file, run_opts={}) ->
+    run_env = run_opts.env or {}
+    env = {k, v for k, v in pairs command_env}
+    env[k] = v for k, v in pairs run_env
     cmdline = "#{cmd} #{file}"
     notify.info cmdline
-    success = execute cmdline
+    success = execute cmdline, :env
     assert success, cmdline
 
 -- For filtering commands not runnable


### PR DESCRIPTION
This allows env variables (in the form of a kv table) to be passed both to the command creation and the actual running of the command (the later takes precedence over any keys set in command).

Eg.

```moonscript
env_cmd = command "ruby", env: {SOMEKEY: "VALUE ONE"}

env_cmd "printenv.rb" -- would print SOMEKEY = VALUE ONE
env_cmd "printenv.rb", {SOMEKEY: "VALUE TWO"} -- would print SOMEKEY = VALUE TWO
```