### PR TITLE
Replace circleci and travisci with buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,16 @@
+steps:
+  - label: Linux build
+    command:
+      - ./.ci/linux.sh
+    agents:
+      queue: linux
+  - label: OSX build
+    command:
+      - ./.ci/osx.sh
+    agents:
+      queue: osx
+  - label: FreeBSD build
+    command:
+      - ./.ci/freebsd.sh
+    agents:
+      queue: freebsd

--- a/.ci/freebsd.sh
+++ b/.ci/freebsd.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+export DEFAULT_ALWAYS_YES=true
+export ASSUME_ALWAYS_YES=true
+
+pkg install tmux
+gmake
+gmake lint
+gmake test

--- a/.ci/linux.sh
+++ b/.ci/linux.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+apt-get update -yqqu
+apt-get install -yqq tmux build-essential git
+make
+make lint
+make test
+kill -s INT $BUILDKITE_AGENT_PID

--- a/.ci/osx.sh
+++ b/.ci/osx.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+brew install tmux
+make
+make lint
+make test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-[![Circle CI](https://circleci.com/gh/johnae/spook.svg?style=svg)](https://circleci.com/gh/johnae/spook)
-[![Travis CI](https://travis-ci.org/johnae/spook.svg?branch=master)](https://travis-ci.org/johnae/spook)
+[![Buildkite CI](https://badge.buildkite.com/41c70ee26c601a323ea26103e67674cae9bdcbaa8fc17786ae.svg?branch=master)](https://buildkite.com/insane/spook) (tests currently run on Linux, macOS and FreeBSD)
 
 ## Spook - react to change
 


### PR DESCRIPTION
This will likely replace building on travis and circleci as buildkite is a more flexible solution (eg. can now build on whatever I want - for starters osx, linux and freebsd).