### PR TITLE
Assorted fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 0.9.4 -- unreleased
 
+Rework kqueue implementation to not rely so much on paths as
+on BSD we watch inodes, not paths (which makes certain things
+difficult to impossible). File moves are not as well supported
+on BSD as on Linux. BSD includes OS X.
+
+To make stdin mode do the expected thing on BSD when an editor
+does an "atomic" save, spook now includes deletions as valid events.
+
 Also handle SIGPIPE and kill children as a result.
 
 Add a debug log level timing output for spook startup.

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,8 @@ lint: spook
 	$(LUAJIT_BIN) spec/support/run_linter.lua spec/*.moon
 
 install: all
-	install -Dm 755 spook $(DESTDIR)$(PREFIX)/bin/spook
+	install -d $(DESTDIR)/$(PREFIX)/bin
+	install -m 755 spook $(DESTDIR)$(PREFIX)/bin/spook
 
 lib/version.moon:
 	@echo "VERSION TAGGING: $(SPOOK_VERSION)"

--- a/init.moon
+++ b/init.moon
@@ -347,6 +347,7 @@ watch_files_from_stdin = (files) ->
   log.debug "Matching events against #{#files} files..."
   spook\watchnr dirs, ->
     on_changed '(.*)', handler
+    on_deleted '(.*)', handler
 
   start!
 

--- a/shpec/spook_shpec.sh
+++ b/shpec/spook_shpec.sh
@@ -233,6 +233,15 @@ EOF
     mv $TESTDIR/watchme/newfile $TESTDIR/watchme/newname ; nap ; nap ; nap
     assert last_log_eq 3 "SPOOK_CHANGE_PATH: watchme/newname\nSPOOK_CHANGE_ACTION: moved\nSPOOK_MOVED_FROM: watchme/newfile"
 
+    mv $TESTDIR/watchme/newname $TESTDIR/watchme/newfile ; nap ; nap ; nap
+    assert last_log_eq 3 "SPOOK_CHANGE_PATH: watchme/newfile\nSPOOK_CHANGE_ACTION: moved\nSPOOK_MOVED_FROM: watchme/newname"
+
+    mv $TESTDIR/watchme/newfile $TESTDIR/watchme/newname ; nap ; nap ; nap
+    assert last_log_eq 3 "SPOOK_CHANGE_PATH: watchme/newname\nSPOOK_CHANGE_ACTION: moved\nSPOOK_MOVED_FROM: watchme/newfile"
+
+    mv $TESTDIR/watchme/newname $TESTDIR/watchme/newfile ; nap ; nap ; nap
+    assert last_log_eq 3 "SPOOK_CHANGE_PATH: watchme/newfile\nSPOOK_CHANGE_ACTION: moved\nSPOOK_MOVED_FROM: watchme/newname"
+
     $TMUX send-keys -t $window C-c ; nap ; nap # ctrl-c / SIGINT
     assert pid_not_running "$spid" "(spook itself)"
 


### PR DESCRIPTION
This mainly fixes stdin events on BSD:s when an editor does an atomic save in a certain way (as intellij does):

write new content to a temp path
move original file path to a temp path
move the "new content" temp path to original path
remove the old original now at some temp path

Since kqueue can't realistically detect these events the fix (for stdin mode) is to just make delete events valid events (eg. they trigger spook to do whatever it was told to do when something happens).

The watcher for BSD:s has been reworked to rely more on inodes (which is what's being watched really on BSD) rather than paths.

There's a fix to event ordering on Linux in here as well.