### PR TITLE
Add ignore option to watch

### DIFF
--- a/Spookfile
+++ b/Spookfile
@@ -80,7 +80,7 @@ lint = (file) ->
 
 -- Watching for changes underneath . and matching them to handlers using
 -- lua patterns (see: http://lua-users.org/wiki/PatternsTutorial for example).
-watch ".", ->
+watch ".", ignore: {'.git', '.direnv'}, ->
 
   on_changed "^spec/spec_helper%.moon", (event) ->
     test event, task_list(

--- a/Spookfile
+++ b/Spookfile
@@ -80,7 +80,7 @@ lint = (file) ->
 
 -- Watching for changes underneath . and matching them to handlers using
 -- lua patterns (see: http://lua-users.org/wiki/PatternsTutorial for example).
-watch ".", ignore: {'.git', '.direnv'}, ->
+watch ".", ignore: {'%.git', '%.direnv'}, ->
 
   on_changed "^spec/spec_helper%.moon", (event) ->
     test event, task_list(

--- a/lib/bsd/event_loop.moon
+++ b/lib/bsd/event_loop.moon
@@ -221,7 +221,8 @@ Watcher = define 'Watcher', ->
         error "None of the given paths (#{concat ["'#{path}'" for path in *paths], ', '}) were accessible"
       @paths = @_paths
       if @recursive
-        @paths = unique_subtrees @_paths
+        {:ignore} = opts
+        @paths = unique_subtrees @_paths, :ignore
       @fflags = convert_to_bsd_flags(watch_for)
       @watch_id = next_id!
       :fflags, :flags = @

--- a/lib/fs.moon
+++ b/lib/fs.moon
@@ -53,11 +53,12 @@ dirtree = (dir, opts={}) ->
 
   :recursive, :ignore = opts
 
-  ignores = {'.', '..'}
+  ignores = {'^%.$', '^%.%.$'}
   append(ignores, ign) for ign in *ignore
   ignored = (entry) ->
     for ign in *ignores
-      return true if entry == ign
+      matches = {entry\match ign}
+      return true if #matches > 0
     false
 
   yieldtree = (current_dir) ->

--- a/lib/fs.moon
+++ b/lib/fs.moon
@@ -2,7 +2,7 @@ require 'globals'
 lfs = require "syscall.lfs"
 S = require 'syscall'
 log = require'log'
-:remove = table
+insert: append, :remove = table
 
 is_dir = (dir) ->
   return false unless type(dir) == "string"
@@ -42,35 +42,50 @@ remove_trailing_slash = (path) ->
     path = path\sub 1, #path - 1
   path
 
-dirtree = (dir, recursive) ->
+dirtree = (dir, opts={}) ->
   assert dir and dir != "", "directory parameter is missing or empty"
   dir = remove_trailing_slash dir
   dir = "/" if dir == "" -- was /
+  -- be backwards compatible
+  if type(opts) == 'boolean'
+    opts = recursive: opts
+  opts.ignore or= {}
+
+  :recursive, :ignore = opts
+
+  ignores = {'.', '..'}
+  append(ignores, ign) for ign in *ignore
+  ignored = (entry) ->
+    for ign in *ignores
+      return true if entry == ign
+    false
 
   yieldtree = (current_dir) ->
     unless can_access(current_dir)
       log.debug "No access to #{dir}, skipping"
       return
     for entry in lfs.dir current_dir
-      if entry != "." and entry != ".."
-        entry = "#{remove_trailing_slash(current_dir)}/#{entry}"
-        unless can_access(entry)
-          log.debug "No access to #{entry}, skipping"
-          continue
-        attr = lfs.attributes entry
-        coroutine.yield entry, attr
-        if recursive and attr.mode == "directory"
-          yieldtree entry, recursive
+      continue if ignored(entry)
+      entry = "#{remove_trailing_slash(current_dir)}/#{entry}"
+      unless can_access(entry)
+        log.debug "No access to #{entry}, skipping"
+        continue
+      attr = lfs.attributes entry
+      coroutine.yield entry, attr
+      if recursive and attr.mode == "directory"
+        yieldtree entry, recursive
 
   coroutine.wrap -> yieldtree dir
 
-unique_subtrees = (paths) ->
+unique_subtrees = (paths, opts={}) ->
+  if opts.recursive == nil
+    opts.recursive = true
   accessible_dir = (entry, attr) ->
     can_access(entry) and
       ((attr or lfs.attributes(entry)).mode == 'directory')
   recursive_dirmap = (dir) ->
     return {} unless accessible_dir(dir)
-    map = { attr.ino, entry for entry, attr in dirtree(dir, true) when accessible_dir(entry, attr) }
+    map = { attr.ino, entry for entry, attr in dirtree(dir, opts) when accessible_dir(entry, attr) }
     map[lfs.attributes(dir).ino] = dir
     map
 

--- a/lib/linux/event_loop.moon
+++ b/lib/linux/event_loop.moon
@@ -83,7 +83,8 @@ Watcher = define 'Watcher', ->
       if #@paths == 0
         error "None of the given paths (#{concat ["'#{path}'" for path in *paths], ', '}) were accessible"
       if @recursive
-        @paths = unique_subtrees @paths
+        {:ignore} = opts
+        @paths = unique_subtrees @paths, :ignore
       @watch_for = watch_for
       @watchers = {}
       @started = false

--- a/lib/spook.moon
+++ b/lib/spook.moon
@@ -11,6 +11,20 @@ to_coro_fs = (spook) ->
   return to_coro unless spook.one_fs_handler_at_a_time
   (fun) -> fun
 
+get_watch_opts = (args, default_opts) ->
+  default_opts or= {}
+  local dirs
+  if type(args[1]) == 'table'
+    dirs = args[1]
+  else
+    dirs = [d for i, d in ipairs args when i<#args and type(d) != 'table']
+  opts = {k,v for k, v in pairs default_opts}
+  if type(args[#args-1]) == 'table' and #args > 2
+    for k, v in pairs args[#args-1]
+      opts[k] = v
+  opts.func = args[#args]
+  dirs, opts
+
 define 'Spook', ->
   properties
     log_level:
@@ -81,10 +95,10 @@ define 'Spook', ->
       if type(dirs) == 'table'
         dirmap = {lfs.attributes(dir).ino, dir for dir in *dirs}
         dirs = [dir for _, dir in pairs dirmap]
-      :recursive, :func = opts
+      :recursive, :ignore, :func = opts
       unless type(func) == 'function'
         error 'last argument to watch must be a setup function'
-      new_watcher = Watcher.new dirs, 'create, delete, modify, move, attrib', :recursive, callback: (w, events) ->
+      new_watcher = Watcher.new dirs, 'create, delete, modify, move, attrib', :recursive, :ignore, callback: (w, events) ->
         append @fs_events, Event.new('fs', e) for e in *events
       append @watchers, new_watcher
       @num_dirs += #new_watcher.paths
@@ -94,16 +108,14 @@ define 'Spook', ->
 
     watchnr: (...) =>
       args = {...}
-      dirs = [d for i, d in ipairs args when i<#args]
-      func = args[#args]
-      @_watch dirs, recursive: false, :func
+      dirs, opts = get_watch_opts args, recursive: false
+      @_watch dirs, opts
 
     -- defines recursive watchers (eg. all directories underneath given directories)
     watch: (...) =>
       args = {...}
-      dirs = [d for i, d in ipairs args when i<#args]
-      func = args[#args]
-      @_watch dirs, recursive: true, :func
+      dirs, opts = get_watch_opts args, recursive: true
+      @_watch dirs, opts
 
     watch_file: (file, func) =>
       dir = '.'

--- a/spec/fs_spec.moon
+++ b/spec/fs_spec.moon
@@ -69,6 +69,41 @@ describe 'fs', ->
       table.sort(contents)
       assert.same expected, contents
 
+    it 'dirtree yields contents of a directory recursively, ignoring given patterns when specified', ->
+      fs.mkdir_p tmpdir .. '/my/dir/structure'
+      f = assert(io.open(tmpdir .. '/my/dir/file.txt', "w"))
+      f\write("spec")
+      f\close!
+      f = assert(io.open(tmpdir .. '/my/dir/.hidden.txt', "w"))
+      f\write("hidden")
+      f\close!
+      contents = {}
+      for entry in fs.dirtree tmpdir, true
+        insert contents, entry
+      expected = {
+        tmpdir .. '/my',
+        tmpdir .. '/my/dir',
+        tmpdir .. '/my/dir/structure',
+        tmpdir .. '/my/dir/file.txt'
+        tmpdir .. '/my/dir/.hidden.txt'
+      }
+      table.sort(expected)
+      table.sort(contents)
+      assert.same expected, contents
+
+      contents = {}
+      for entry in fs.dirtree tmpdir, recursive: true, ignore: {'^%.hidden%.txt$'}
+        insert contents, entry
+      expected = {
+        tmpdir .. '/my',
+        tmpdir .. '/my/dir',
+        tmpdir .. '/my/dir/structure',
+        tmpdir .. '/my/dir/file.txt'
+      }
+      table.sort(expected)
+      table.sort(contents)
+      assert.same expected, contents
+
   describe 'name_ext', ->
 
     it 'returns the filename and extension as two parameters', ->


### PR DESCRIPTION
This allows ignoring certain file name patterns in the watch function, like:

```moonscript
watch ".", ignore: {'%.git$', '%.direnv$'}, -> 
  on_changed ... etc
```