### PR TITLE
Use nix to generate build buildkite pipelines.

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+## always build this before running command
+## this way we ensure parallel jobs have all
+## they need
+nix-build .buildkite/pipeline.nix

--- a/.buildkite/pipeline.nix
+++ b/.buildkite/pipeline.nix
@@ -49,4 +49,4 @@ in
       '';
     })
 
-] ++ cache-steps)
+  ] ++ cache-steps)

--- a/.buildkite/pipeline.nix
+++ b/.buildkite/pipeline.nix
@@ -1,21 +1,52 @@
 with import ./buildkite.nix;
-pipeline [
 
-  (step ":pipeline: Build and Test" {
-    environment = [ "CACHIX_SIGNING_KEY" ];
-    agents = [ "queue=linux" "nix=true" ];
-    command = ''
-      nix-shell --run bash <<'NIXSH'
-        echo --- Build spook
-        make
+let
 
-        echo +++ Lint
-        make lint
+  cache-steps = if builtins.getEnv "BUILDKITE_BRANCH" == "master" then
+  [
+    wait
 
-        echo +++ Test
-        make test
-      NIXSH
-    '';
-  })
+    (
+      step ":pipeline: Populate cachix cache" {
+        environment = [ "CACHIX_SIGNING_KEY" ];
+        agents = [ "queue=linux" "nix=true" ];
+        command = ''
+          echo --- Populate cachix cache
+          if [ -z "$CACHIX_SIGNING_KEY" ]; then
+             echo "Missing environment variable CACHIX_SIGNING_KEY"
+             exit 1
+          fi
+          nix-env -iA cachix -f https://cachix.org/api/v1/install
+          nix-store -qR --include-outputs "$(nix-instantiate build.nix)" | \
+          tee /dev/tty | \
+          cachix push insane
+        '';
+      }
+    )
+  ] else [];
 
-]
+in
+
+  pipeline ([
+
+    (step ":pipeline: Lint" {
+      agents = [ "queue=linux" "nix=true" ];
+      command = ''
+        nix-shell --run bash <<'NIXSH'
+          echo +++ Lint
+          make lint
+        NIXSH
+      '';
+    })
+
+    (step ":pipeline: Test" {
+      agents = [ "queue=linux" "nix=true" ];
+      command = ''
+        nix-shell --run bash <<'NIXSH'
+          echo +++ Test
+          make test
+        NIXSH
+      '';
+    })
+
+] ++ cache-steps)

--- a/build.nix
+++ b/build.nix
@@ -1,0 +1,25 @@
+with import <nixpkgs> {};
+
+stdenv.mkDerivation rec {
+  version = "0.9.7-pre";
+  name = "spook-${version}";
+  SPOOK_VERSION = version;
+
+  src = ./.;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    make install PREFIX=$out
+    runHook postInstall
+  '';
+
+  buildInputs = [ gnumake gcc wget perl cacert ];
+
+  meta = {
+    description = "Lightweight evented utility for monitoring file changes and more";
+    homepage = https://github.com/johnae/spook;
+    license = "MIT";
+  };
+
+}


### PR DESCRIPTION
Also add cachix caching as build step. Add a build.nix. We now rely on
a buildkite hook to ensure all nix derivations are present before
running step command. This is so that when the job is parallelized we
still have everything necessary to run any step. Since Nix knows
what's already present this takes no time if nothing needs to be done
really.