### PR TITLE
Buildkite: build without docker, improve pipeline generation.

### DIFF
--- a/.buildkite/buildkite.nix
+++ b/.buildkite/buildkite.nix
@@ -3,63 +3,23 @@ with lib;
 
 let
 
-  writeStrictShellScript = name: text:
-    writeTextFile {
-      inherit name;
-      executable = true;
-      text = ''
-        #!${stdenv.shell}
-        set -euo pipefail
-        ${text}
-      '';
-      checkPhase = ''
-        ## check the syntax
-        ${stdenv.shell} -n $out
-        ## shellcheck
-        ${shellcheck}/bin/shellcheck -e SC1117 -s bash -f tty $out
-      '';
-    };
-
   step = label: {
     command,
-    withPkgs ? [],
     environment ? [],
     agents ? [],
-    timeout ? 600,
-    volumes ? [ "/var/lib/buildkite/nix:/nix" ],
-    plugins ? [
-      {
-        "docker#v3.0.1" = {
-          image = builtins.getEnv "NIXIMAGE";
-          mount-buildkite-agent = false;
-          entrypoint = "/usr/bin/bash";
-          inherit environment volumes;
-        };
-      }
-    ]
+    timeout ? 600
     }:
       {
-        inherit label timeout plugins agents;
-        command = writeStrictShellScript
-         (toLower (
-           replaceStrings [" "] ["-"] (
-             replaceStrings [ ":" ] [""] (toString label)))) ''
-               export PATH=${if length withPkgs > 0 then
-               ''${makeSearchPath "bin" withPkgs }:$PATH''
-               else
-               ''$PATH''
-               }
-               ${command}
-             '';
+        inherit label timeout agents command;
       };
 
-   wait = "wait";
+  wait = "wait";
 
-   pipeline = s:
-     writeTextFile {
-      name = "pipeline.json";
-      text = builtins.toJSON (s);
-     };
+  pipeline = s:
+    writeTextFile {
+     name = "pipeline.json";
+     text = builtins.toJSON (s);
+    };
 
 
 in

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-## always build this before running command
-## this way we ensure parallel jobs have all
-## they need
-nix-build .buildkite/pipeline.nix

--- a/.buildkite/pipeline.nix
+++ b/.buildkite/pipeline.nix
@@ -1,52 +1,65 @@
 with import ./buildkite.nix;
+with builtins;
+with lib;
 
 let
 
-  cache-steps = if builtins.getEnv "BUILDKITE_BRANCH" == "master" then
-  [
-    wait
-
-    (
-      step ":pipeline: Populate cachix cache" {
-        environment = [ "CACHIX_SIGNING_KEY" ];
-        agents = [ "queue=linux" "nix=true" ];
-        command = ''
-          echo --- Populate cachix cache
-          if [ -z "$CACHIX_SIGNING_KEY" ]; then
-             echo "Missing environment variable CACHIX_SIGNING_KEY"
-             exit 1
-          fi
-          nix-env -iA cachix -f https://cachix.org/api/v1/install
-          nix-store -qR --include-outputs "$(nix-instantiate build.nix)" | \
-          tee /dev/tty | \
-          cachix push insane
-        '';
-      }
-    )
-  ] else [];
+  ## build on macos as well when infra is in place
+  #run-on-agents = [["queue=linux" "nix=true"]
+  #          ["queue=macos" "nix=true"]];
+  run-on-agents = [[ "queue=linux" "nix=true" ]];
 
 in
 
-  pipeline ([
+  pipeline (
 
-    (step ":pipeline: Lint" {
-      agents = [ "queue=linux" "nix=true" ];
-      command = ''
-        nix-shell --run bash <<'NIXSH'
-          echo +++ Lint
-          make lint
-        NIXSH
-      '';
-    })
+   flatten (map (agents: [
+
+     (step ":pipeline: Lint" {
+       inherit agents;
+       command = ''
+         nix-shell --run bash <<'NIXSH'
+           echo +++ Lint
+           make lint
+         NIXSH
+       '';
+     })
 
     (step ":pipeline: Test" {
-      agents = [ "queue=linux" "nix=true" ];
-      command = ''
-        nix-shell --run bash <<'NIXSH'
-          echo +++ Test
-          make test
-        NIXSH
-      '';
+       inherit agents;
+       command = ''
+         nix-shell --run bash <<'NIXSH'
+           echo +++ Test
+           make test
+         NIXSH
+       '';
     })
 
-  ] ++ cache-steps)
+   ]
+
+   ++
+
+   (if getEnv "BUILDKITE_BRANCH" == "master" then
+     [
+       wait
+       (step ":pipeline: Populate cachix cache" {
+         inherit agents;
+         environment = [ "CACHIX_SIGNING_KEY" ];
+         command = ''
+           echo --- Populate cachix cache
+           if [ -z "$CACHIX_SIGNING_KEY" ]; then
+              echo "Missing environment variable CACHIX_SIGNING_KEY"
+              exit 1
+           fi
+           nix-env -iA cachix -f https://cachix.org/api/v1/install
+           nix-store -qR --include-outputs "$(nix-instantiate build.nix)" | \
+           tee /dev/tty | \
+           cachix push insane
+         '';
+         })
+     ]
+    else [])
+    )
+   run-on-agents ## map
+  )
+)

--- a/.buildkite/result
+++ b/.buildkite/result
@@ -1,0 +1,1 @@
+/nix/store/nfn03nb0annnfzaya67qpah0fk4w795j-pipeline.json


### PR DESCRIPTION
Stop relying on nix built scripts as they become an issue when
building both Linux and Darwin. The actual build details should
be handled outside of the pipeline generation anyway I think.

This also means we don't need a pre-build hook atm.